### PR TITLE
Optionally measure block even when exception occurs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ StatsD.prefix = nil # but can be set to any string
 # Sample 10% of events. By default all events are reported, which may overload your network or server.
 # You can, and should vary this on a per metric basis, depending on frequency and accuracy requirements
 StatsD.default_sample_rate = (ENV['STATSD_SAMPLE_RATE'] || 0.1 ).to_f
+
+# Optionally measure block even if there is an exception
+StatsD.measure_on_exception = true # default is false
 ```
 
 ## StatsD keys

--- a/test/statsd_test.rb
+++ b/test/statsd_test.rb
@@ -48,6 +48,25 @@ class StatsDTest < Minitest::Test
     assert_equal 'sarah', return_value
   end
 
+  def test_statsd_measure_dont_measure_on_exception
+    metrics = capture_statsd_calls {
+      StatsD.measure('values.foobar') { raise(StandardError) } rescue nil
+    }
+
+    assert_equal 0, metrics.length
+  end
+
+  def test_statsd_measure_do_measure_on_exception
+    StatsD.measure_on_exception = true
+    metric = capture_statsd_call {
+      StatsD.measure('values.foobar') { raise(StandardError) } rescue nil
+    }
+
+    assert_instance_of Float, metric.value
+  ensure
+    StatsD.measure_on_exception = false
+  end
+
   def test_statsd_increment
     result = nil
     metric = capture_statsd_call { result = StatsD.increment('values.foobar', 3) }


### PR DESCRIPTION
Hey guys (Shopify and contributors)!

First of all thanks so much for the `statsd-instrument` gem. It helps us scale our system at [Onfido](https://onfido.com/).

This pull request introduces a feature that we found could be useful for certain projects. Maybe this is not the right way to achieve it. I'd like your feedback on it. 😅 

We've ran into timeouts that yielded exceptions in wrapped `StatsD.measure` calls. This lead to timeouts not being reported to Datadog, which effectively resulted in biased dashboards and flawed monitoring. What we'd like to know, for better data collection and analysis, is how much time something took **even if that something fails**.

I've added a global option, `StatsD.measure_on_exception` that tells `statsd-instrument` to keep collecting time metrics even if we get an exception (i.e., `StatsD.measure` will still measure even if the code it wraps fails with a `StandardError`).

Default behaviour is retro-compatible.

To test it, I've added unit tests and used the following prototypes to do some integration testing:

- Dumb server that times out:

```
require "sinatra"

get "/*" do
  sleep 10

  [200, {"Content-Type" => "application/json"}, JSON.dump({})]
end

```

- Client reporting metrics:

```
require "httpclient"
require "statsd-instrument"

StatsD.measure_on_exception = true

class Test
  def call
    client = HTTPClient.new
    client.receive_timeout = 2
    client.get("http://localhost:4567")
  end

  extend StatsD::Instrument
  statsd_measure :call, "test.timeout"
  statsd_count_success :call, "test.timeout"
end
```

Before this change, we did not measure on exception:

```
2.3.1 :001 > Test.new.call
I, [2017-11-02T11:12:32.427451 #4726]  INFO -- : [StatsD] increment test.timeout.failure:1
HTTPClient::ReceiveTimeoutError: execution expired
```

After adding this, we measure on exception:

```
2.3.1 :001 > Test.new.call
I, [2017-11-02T11:12:06.369905 #4703]  INFO -- : [StatsD] measure test.timeout:2005.029140971601
I, [2017-11-02T11:12:06.370001 #4703]  INFO -- : [StatsD] increment test.timeout.failure:1
HTTPClient::ReceiveTimeoutError: execution expired
```

Thanks to my colleague and friend @jcmfernandes who paired with me on this. 😊 

What do you guys think?